### PR TITLE
Convert testg9624346/test2-coverage-report to GitHub Actions

### DIFF
--- a/.github/workflows/test2-coverage-report.yml
+++ b/.github/workflows/test2-coverage-report.yml
@@ -1,0 +1,30 @@
+name: testg9624346/test2-coverage-report
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+jobs:
+  install_node:
+    runs-on: ubuntu-latest
+    container:
+      image: node:latest
+    timeout-minutes: 60
+    env:
+      TEST_VAR: "${{ secrets.TEST_VAR }}"
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: node --version
+    - run: npm --version
+    - run: echo "Testing variable $TEST_VAR"
+    - uses: actions/upload-artifact@v4.0.0
+      if: success()
+      with:
+        name: "${{ github.job }}"
+        path: |-
+          node_version.txt
+          npm_version.txt


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.com/testg9624346/test2-coverage-report) :tada:

## Manual steps

Perform the following steps to complete the migration:

### testg9624346/test2-coverage-report
- [ ] Ensure secret is available: `${{ secrets.TEST_VAR }}`